### PR TITLE
Added system independent line separator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 .classpath
 .project
 .settings
+
+#IntelliJ IDEA generated folder
+.idea

--- a/src/main/java/javatools/parsers/Char17.java
+++ b/src/main/java/javatools/parsers/Char17.java
@@ -424,7 +424,7 @@ public class Char17 {
           i++;
           continue;
         case 'n':
-          result.append((char) 10);
+          result.append(System.lineSeparator());
           i++;
           continue;
         case 'f':


### PR DESCRIPTION
When trying to compile the project "basics3", two of the unit tests failed with the error below. Looking for the reason, i found that the method on "javatools (current lib)" was assuming that the "break character" was (char)10... but in Windows, it is "\r\n". A solution is then to use the System.lineSeparator() which is system independent, and it should have the correct value for Windows, Linux or MacOS. 

This fix is enough to correct the unit test error then. Thanks!


```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running basics.N4ReaderTest
Warning: Cannot handle list  ( <unknown source> )
Tests run: 32, Failures: 2, Errors: 0, Skipped: 11, Time elapsed: 0.387 sec <<< FAILURE! - in basics.N4ReaderTest
test17(basics.N4ReaderTest)  Time elapsed: 0.024 sec  <<< FAILURE!
org.junit.internal.ArrayComparisonFailure: arrays first differed at element [0]; expected:<<http://example.org/ex#a> <http://example.org/ex#b> "a long\n\u0009literal\nwith\nnewlines"> but was:<<http://example.org/ex#a> <http://example.org/ex#b> "a long\u000d\n\u000
9literal\u000d\nwith\u000d\nnewlines">
        at org.junit.Assert.fail(Assert.java:88)
        at org.junit.Assert.failNotEquals(Assert.java:834)
        at org.junit.Assert.assertEquals(Assert.java:118)
        at org.junit.Assert.assertEquals(Assert.java:144)
        at org.junit.internal.ExactComparisonCriteria.assertElementsEqual(ExactComparisonCriteria.java:8)
        at org.junit.internal.ComparisonCriteria.arrayEquals(ComparisonCriteria.java:53)
        at org.junit.Assert.internalArrayEquals(Assert.java:532)
        at org.junit.Assert.assertArrayEquals(Assert.java:283)
        at org.junit.Assert.assertArrayEquals(Assert.java:298)
        at basics.N4ReaderTest.runAndCompare(N4ReaderTest.java:343)
        at basics.N4ReaderTest.test17(N4ReaderTest.java:192)

test18(basics.N4ReaderTest)  Time elapsed: 0.021 sec  <<< FAILURE!
org.junit.internal.ArrayComparisonFailure: arrays first differed at element [0]; expected:<<http://example.org/foo#a> <http://example.org/foo#b> "\nthis \u000dis a \\U00015678long\u0009\nliteral?\n"> but was:<<http://example.org/foo#a> <http://example.org/foo#b> "\
nthis \u000dis a \\U00015678long\u0009\u000d\nliteral?\u000d\n">
        at org.junit.Assert.fail(Assert.java:88)
        at org.junit.Assert.failNotEquals(Assert.java:834)
        at org.junit.Assert.assertEquals(Assert.java:118)
        at org.junit.Assert.assertEquals(Assert.java:144)
        at org.junit.internal.ExactComparisonCriteria.assertElementsEqual(ExactComparisonCriteria.java:8)
        at org.junit.internal.ComparisonCriteria.arrayEquals(ComparisonCriteria.java:53)
        at org.junit.Assert.internalArrayEquals(Assert.java:532)
        at org.junit.Assert.assertArrayEquals(Assert.java:283)
        at org.junit.Assert.assertArrayEquals(Assert.java:298)
        at basics.N4ReaderTest.runAndCompare(N4ReaderTest.java:343)
        at basics.N4ReaderTest.test18(N4ReaderTest.java:201)


Results :

Failed tests:
  N4ReaderTest.test17:192->runAndCompare:343 arrays first differed at element [0]; expected:<<http://example.org/ex#a> <http://example.org/ex#b> "a long\n\u0009literal\nwith\nnewlines"> but was:<<http://example.org/ex#a> <http://example.org/ex#b> "a long\u000d\n\u0
009literal\u000d\nwith\u000d\nnewlines">
  N4ReaderTest.test18:201->runAndCompare:343 arrays first differed at element [0]; expected:<<http://example.org/foo#a> <http://example.org/foo#b> "\nthis \u000dis a \\U00015678long\u0009\nliteral?\n"> but was:<<http://example.org/foo#a> <http://example.org/foo#b>
"\nthis \u000dis a \\U00015678long\u0009\u000d\nliteral?\u000d\n">

Tests run: 32, Failures: 2, Errors: 0, Skipped: 11
```